### PR TITLE
Dont hide nameplates if shield not full

### DIFF
--- a/VikingNameplates/VikingNameplates.lua
+++ b/VikingNameplates/VikingNameplates.lua
@@ -720,13 +720,14 @@ function VikingNameplates:DrawHealth(tNameplate)
   end
 
   local bUseTarget = tNameplate.bIsTarget
+  local bMaxHealthAndShield = unitOwner:GetHealth() == unitOwner:GetMaxHealth() and unitOwner:GetShieldCapacity() == unitOwner:GetShieldCapacityMax()
   if bUseTarget then
     self:ToggleNamePlatesVisiblity(tNameplate, self.bShowHealthTarget)
   else
     if self.bShowHealthMain then
       self:ToggleNamePlatesVisiblity(tNameplate, true)
     elseif self.bShowHealthMainDamaged then
-      self:ToggleNamePlatesVisiblity(tNameplate, unitOwner:GetHealth() ~= unitOwner:GetMaxHealth())
+      self:ToggleNamePlatesVisiblity(tNameplate, bMaxHealthAndShield ~= true)
     else
       self:ToggleNamePlatesVisiblity(tNameplate, false)
     end


### PR DESCRIPTION
Nameplates will only auto-hide if both health and shields are not at max. Previously, if the health was full, but shields were damaged, then the nameplates would hide. 
This only affects nameplates when the "If Damaged" option is selected.

Resolves Issue #59 
